### PR TITLE
Add confirmation dialog when deleting items

### DIFF
--- a/main.js
+++ b/main.js
@@ -196,9 +196,11 @@ function onItemEdit(item) {
 }
 
 function deleteItem(item) {
-  item.remove();
-  deleteFromLocalStorage(item.getAttribute("data-key"));
-  reloadList();
+  if (confirm("Remove item from resume?")) {
+    item.remove();
+    deleteFromLocalStorage(item.getAttribute("data-key"));
+    reloadList();
+  }
 }
 
 function deleteFromLocalStorage(index) {
@@ -208,12 +210,13 @@ function deleteFromLocalStorage(index) {
 }
 
 function clearList() {
-  while (itemList.firstChild) {
-    itemList.removeChild(itemList.firstChild);
+  if (confirm("Clear resume? You cannot undo this action.")) {
+    while (itemList.firstChild) {
+      itemList.removeChild(itemList.firstChild);
+    }
+    localStorage.removeItem("items");
+    reloadList();
   }
-
-  localStorage.removeItem("items");
-  reloadList();
 }
 
 function reloadList() {


### PR DESCRIPTION
## Summary

This PR adds a confirmation dialog when deleting individual items from the resume and clearing the entire resume list in `main.js`. This ensures that users are prompted to confirm their action before an item is permanently deleted, reducing the risk of accidental deletions.

## Changes

- **main.js**: Added a `confirm` dialog box for functions **deleteItem** and **clearList**

## Testing

- Manually tested the confirmation dialog in the browser.
- Verified that the deletion only occurs after user confirmation.
- Ensured that the existing functionality remains unaffected.

## Screenshots
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/51c064b6-40dd-4b05-a90f-6440624078f7">
<img width="972" alt="image" src="https://github.com/user-attachments/assets/ca9904b3-6013-44e9-a9b9-c240045bd08a">
