### PR TITLE
Cancel edit mode when after deleting

### DIFF
--- a/main.js
+++ b/main.js
@@ -198,6 +198,7 @@ function onItemEdit(item) {
 function deleteItem(item) {
   item.remove();
   deleteFromLocalStorage(item.getAttribute("data-key"));
+  if (isEditing) onCancelEdit();
   reloadList();
 }
 


### PR DESCRIPTION
## Summary

This PR cancels editing mode on a list entry when the user successfully deletes another item. This prevents the user from being stuck in editing mode when the list reloads.

## Changes

- **main.js**: Added a `confirm` dialog box for functions **deleteItem** and **clearList**
- Merged master branch (main) into feature-y branch and resolved conflicts

## Testing

- Manually tested that edit mode is cancelled upon item deletion.
- Verified that the item previously being edited is back in its default state and that input fiels are empty.
- Ensured that the existing functionality remains unaffected.

## Screenshots
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/94cb263d-1dac-4549-9324-98f126e4d689">
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/a27a05b8-375c-4dba-861f-9485b0d19e1c">
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/e5c9e115-e821-47be-993c-b8d9cfec9c30">

